### PR TITLE
fix(templates)!: rename tokenSeperator param to tokenSeparator

### DIFF
--- a/assets/scss/_base.scss
+++ b/assets/scss/_base.scss
@@ -17,6 +17,16 @@ body {
 }
 
 a {
+    color: $link-color;
+    text-decoration: underline;
+    text-decoration-thickness: .1rem;
+    text-underline-offset: .15em;
+    transition: color 0.2s;
+
+    &:visited {
+        color: $link-color;
+    }
+
     &:focus-visible {
         @include focus-ring;
         color: $link-color-hover;
@@ -25,15 +35,6 @@ a {
     &:hover,
     &:active {
         color: $link-color-hover;
-    }
-
-    &:link,
-    &:visited {
-        color: $link-color;
-        text-decoration: underline;
-        text-decoration-thickness: .1rem;
-        text-underline-offset: .15em;
-        transition: color 0.2s;
     }
 }
 

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -6,6 +6,7 @@ theme = "hugo-theme-vault"
 [params]
   description = "A minimalist Hugo theme for blogs and personal sites"
   latestposts = 5
+  tokenSeparator = "|"
 
 # Social links - uncomment to enable
 # [params.social]

--- a/hugo.toml
+++ b/hugo.toml
@@ -8,5 +8,9 @@ source = "layouts"
 target = "layouts"
 
 [[module.mounts]]
+source = "layouts/_shortcodes"
+target = "layouts/shortcodes"
+
+[[module.mounts]]
 source = "static"
 target = "static"

--- a/layouts/404.html
+++ b/layouts/404.html
@@ -1,5 +1,5 @@
 {{ define "title" }}
-    Page Not Found {{ .Site.Params.tokenSeperator | markdownify }} {{ .Site.Title }}
+    Page Not Found {{ .Site.Params.tokenSeparator | markdownify }} {{ .Site.Title }}
 {{ end }}
 
 {{ define "main" }}

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -1,5 +1,5 @@
 {{ define "title" }}
-    {{ if eq .Kind "taxonomy" }}Tagged {{ end }}{{ .Title | markdownify | singularize }} {{ .Site.Params.tokenSeperator | markdownify }} {{ .Site.Title }}
+    {{ if eq .Kind "taxonomy" }}Tagged {{ end }}{{ .Title | markdownify | singularize }} {{ .Site.Params.tokenSeparator | markdownify }} {{ .Site.Title }}
 {{ end }}
 
 {{ define "main" }}
@@ -20,7 +20,7 @@
                 <time class="metadata published" datetime='{{ .Date.Format "2006-01-02" }}'>{{ .Date.Format $dateFormat }}</time>
                 <h2 class='title'><a href="{{ .RelPermalink }}">{{ .Title }}</a></h2>
                 {{ with .Description }}
-                    <h3 class='description'>{{ . }}</h3>
+                    <p class='description'>{{ . }}</p>
                 {{ end }}
             </section>
             {{ end }}

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -1,5 +1,5 @@
 {{ define "title" }}
-    {{ .Title | markdownify }} {{ .Site.Params.tokenSeperator | markdownify }} {{ .Site.Title }}
+    {{ .Title | markdownify }} {{ .Site.Params.tokenSeparator | markdownify }} {{ .Site.Title }}
 {{ end }}
 
 {{ define "main" }}
@@ -7,7 +7,7 @@
     <header>
         <h1>{{ .Title }}</h1>
         {{ with .Description }}
-        <h2 class='description'>{{ . }}</h2>
+        <p class='description'>{{ . }}</p>
         {{ end }}
     </header>
     {{ .Content }}

--- a/layouts/partials/head/includes.html
+++ b/layouts/partials/head/includes.html
@@ -19,4 +19,14 @@
 
 {{ $css := resources.Get "scss/main.scss" | toCSS | fingerprint }}
 <link rel="stylesheet" href="{{ $css.RelPermalink }}" integrity="{{ $css.Data.Integrity }}" crossorigin="anonymous">
+{{- range .Site.Params.custom.css }}
+  {{- with resources.Get . | fingerprint }}
+<link rel="stylesheet" href="{{ .RelPermalink }}" integrity="{{ .Data.Integrity }}" crossorigin="anonymous">
+  {{- end }}
+{{- end }}
+{{- range .Site.Params.custom.js }}
+  {{- with resources.Get . | fingerprint }}
+<script src="{{ .RelPermalink }}" integrity="{{ .Data.Integrity }}" crossorigin="anonymous" defer></script>
+  {{- end }}
+{{- end }}
 <script>(function(){const t=localStorage.getItem("theme");const d=t==="dark"||(!t&&window.matchMedia("(prefers-color-scheme: dark)").matches);d&&document.documentElement.classList.add("dark")})()</script>

--- a/layouts/post/single.html
+++ b/layouts/post/single.html
@@ -1,5 +1,5 @@
 {{ define "title" }}
-    {{ .Title | markdownify }} {{ .Site.Params.tokenSeperator | markdownify }} {{ .Site.Title }}
+    {{ .Title | markdownify }} {{ .Site.Params.tokenSeparator | markdownify }} {{ .Site.Title }}
 {{ end }}
 
 {{ define "main" }}
@@ -8,15 +8,15 @@
     <header>
         <h1 class='title'>{{ .Title }}</h1>
         {{ with .Description }}
-        <h2 class='description'>{{ . }}</h2>
+        <p class='description'>{{ . }}</p>
         {{ end }}
         <section class='metadata'>
             <time class="published" datetime='{{ .Date.Format "2006-01-02" }}'>{{ .Date.Format $dateFormat }}</time>
-            {{ .Site.Params.tokenSeperator | markdownify }}
+            {{ .Site.Params.tokenSeparator | markdownify }}
             {{ .WordCount }} Words
-            {{ .Site.Params.tokenSeperator | markdownify }}
+            {{ .Site.Params.tokenSeparator | markdownify }}
             {{ .ReadingTime }} minute read
-            {{ .Site.Params.tokenSeperator | markdownify }}
+            {{ .Site.Params.tokenSeparator | markdownify }}
             <nav class="taxonomy" aria-label="Post tags and categories">
                 {{ if isset .Params "tags" }}
                     {{ .Render "tags" }}


### PR DESCRIPTION
## What

Corrects the long-standing misspelling of the `tokenSeperator` site param across all templates. The param is renamed to `tokenSeparator` everywhere it is read.

**This is a breaking change.** Any consumer who configured this param must update their `config.toml`.

## Migration

```toml
[params]
-  tokenSeperator = "|"
+  tokenSeparator = "|"
```

## Affected templates

- `layouts/_default/single.html`
- `layouts/post/single.html`
- `layouts/_default/list.html`
- `layouts/404.html`

The `exampleSite/config.toml` is also updated to use the correct spelling with a default value of `|`.

## Notes

- Branches from `bugfix/post-use-fixes` (PR #32). Merge that PR first so this targets `main` cleanly.
- The `BREAKING CHANGE` in this commit drives a **major bump (2.0.0)**.