### PR TITLE
feat(theme): add smooth theme transition and remove toggle padding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -382,3 +382,4 @@ __pycache__/
 
 
 # End of https://www.gitignore.io/api/node,hugo,less,sublimetext,visualstudio,visualstudiocode
+hugo

--- a/assets/scss/_base.scss
+++ b/assets/scss/_base.scss
@@ -1,12 +1,14 @@
 html {
     background-color: $color-background;
     font-size: $font-size;
+    transition: background-color 0.3s ease;
 }
 
 body {
     background-color: $color-background;
     border-top: $layout-border-top-width solid $color-primary;
     color: $font-color;
+    transition: background-color 0.3s ease, border-color 0.3s ease, color 0.3s ease;
     font-family: $font-family-serif;
     font-feature-settings: "kern", "liga", "clig", "calt";
     font-kerning: normal;

--- a/assets/scss/_theme-toggle.scss
+++ b/assets/scss/_theme-toggle.scss
@@ -15,7 +15,6 @@
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    padding: 0 .25rem;
     cursor: pointer;
     color: var(--color-text);
     vertical-align: middle;
@@ -24,14 +23,10 @@
         @include focus-ring;
     }
 
-    @include screen-medm {
-        padding: 0 .5rem;
-    }
-
     svg {
-        width: 18px;
         height: 18px;
         transition: scale 300ms ease-in-out, rotate 500ms cubic-bezier(0.4, 0, 0.2, 1);
+        width: 18px;
     }
 
     #sun-icon {
@@ -40,10 +35,11 @@
     }
 
     #moon-icon {
-        scale: 0;
         rotate: 0turn;
+        scale: 0;
     }
 }
+
 
 :root:has(input#theme-toggle:checked),
 :root.dark {

--- a/layouts/partials/theme-selector.html
+++ b/layouts/partials/theme-selector.html
@@ -25,16 +25,10 @@
         toggle.addEventListener("change", function() {
             if (this.checked) {
                 document.documentElement.classList.add("dark");
-                try {
-                    localStorage.setItem("theme", "dark");
-                } catch (e) {
-                }
+                try { localStorage.setItem("theme", "dark"); } catch (e) {}
             } else {
                 document.documentElement.classList.remove("dark");
-                try {
-                    localStorage.setItem("theme", "light");
-                } catch (e) {
-                }
+                try { localStorage.setItem("theme", "light"); } catch (e) {}
             }
         });
     })();


### PR DESCRIPTION
## What

Adds a CSS-only fade transition between light and dark themes, and removes the unnecessary horizontal padding from the theme toggle button.

## Why

The toggle had visual padding inconsistent with the nav link spacing. The theme switch was also instant with no visual feedback — a subtle fade makes the change feel intentional rather than jarring.

## How

Transitions on `background-color`, `color`, and `border-color` on `html` and `body` provide a clean 0.3s ease fade whenever the `.dark` class is toggled. No JavaScript changes, no View Transitions API dependency — degrades gracefully everywhere.